### PR TITLE
require librt

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,7 @@ compgen_sources = files(
 )
 
 cc = meson.get_compiler('c')
+librt = cc.find_library('rt', required: false)
 libm = cc.find_library('m', required: false)
 freetype = dependency('freetype2')
 harfbuzz = dependency('harfbuzz')
@@ -125,7 +126,7 @@ endforeach
 executable(
   'tofi',
   tofi_sources, wl_proto_src, wl_proto_headers,
-  dependencies: [libm, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon],
+  dependencies: [librt, libm, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon],
   install: true
 )
 


### PR DESCRIPTION
Linking would fail on my system
```
/usr/bin/ld: /tmp/cc0hywBM.ltrans0.ltrans.o: in function `surface_init':
<artificial>:(.text+0x23d2): undefined reference to `shm_open'
/usr/bin/ld: <artificial>:(.text+0x23e5): undefined reference to `shm_unlink'
collect2: error: ld returned 1 exit status
```

need librt for it compile