### PR TITLE
Set the minimum required meson version to 0.61

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@ project(
   'c',
   version: '0.6.0',
   license: 'MIT',
+  meson_version: '>=0.61.0',
   default_options: [
     'c_std=c2x',
     'optimization=3',

--- a/meson.build
+++ b/meson.build
@@ -147,7 +147,7 @@ endif
 
 # Generate the necessary Wayland headers / sources with wayland-scanner
 wayland_scanner = find_program(
-  wayland_scanner_dep.get_pkgconfig_variable('wayland_scanner'),
+  wayland_scanner_dep.get_variable(pkgconfig: 'wayland_scanner'),
   native: true
 )
 
@@ -198,7 +198,7 @@ if scdoc.found()
     input: 'doc/tofi.1.scd',
     output: output,
     command: [
-      sh, '-c', '@0@ < @INPUT@ > @1@'.format(scdoc.path(), output)
+      sh, '-c', '@0@ < @INPUT@ > @1@'.format(scdoc.full_path(), output)
     ],
     install: true,
     install_dir: '@0@/man1'.format(mandir)
@@ -223,7 +223,7 @@ if scdoc.found()
     input: 'doc/tofi.5.scd',
     output: output,
     command: [
-      sh, '-c', '@0@ < @INPUT@ > @1@'.format(scdoc.path(), output)
+      sh, '-c', '@0@ < @INPUT@ > @1@'.format(scdoc.full_path(), output)
     ],
     install: true,
     install_dir: '@0@/man5'.format(mandir)


### PR DESCRIPTION
The `install_symlink` was only introduced in version 0.61 of meson https://mesonbuild.com/Release-notes-for-0-61-0.html#install_symlink-function