### PR TITLE
Unbreak build on non-GNU by adding missing include

### DIFF
--- a/src/lock.c
+++ b/src/lock.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/file.h>
+#include <sys/stat.h>
 #include "log.h"
 #include "xmalloc.h"
 


### PR DESCRIPTION
Injecting `#error` into `<sys/stat.h>` on a non-affected system may give a clue where it's implicitly included.