### PR TITLE
Fixed compilation under musl libc

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -139,6 +139,8 @@ wayland_scanner_dep = dependency('wayland-scanner', native: true)
 xkbcommon = dependency('xkbcommon')
 glib = dependency('glib-2.0')
 gio_unix = dependency('gio-unix-2.0')
+# On systems where libc doesn't provide fts (i.e. musl) we require libfts
+libfts = cc.find_library('fts', required: not cc.has_function('fts_read'))
 
 if wayland_client.version().version_compare('<1.20.0')
   add_project_arguments(
@@ -189,7 +191,7 @@ subdir('test')
 executable(
   'tofi',
   files('src/main.c'), common_sources, wl_proto_src, wl_proto_headers,
-  dependencies: [librt, libm, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix],
+  dependencies: [librt, libm, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix, libfts],
   install: true
 )
 

--- a/meson.build
+++ b/meson.build
@@ -129,6 +129,8 @@ compgen_sources = files(
 cc = meson.get_compiler('c')
 librt = cc.find_library('rt', required: false)
 libm = cc.find_library('m', required: false)
+# On systems where libc doesn't provide fts (i.e. musl) we require libfts
+libfts = cc.find_library('fts', required: not cc.has_function('fts_read'))
 freetype = dependency('freetype2')
 harfbuzz = dependency('harfbuzz')
 cairo = dependency('cairo')
@@ -139,8 +141,6 @@ wayland_scanner_dep = dependency('wayland-scanner', native: true)
 xkbcommon = dependency('xkbcommon')
 glib = dependency('glib-2.0')
 gio_unix = dependency('gio-unix-2.0')
-# On systems where libc doesn't provide fts (i.e. musl) we require libfts
-libfts = cc.find_library('fts', required: not cc.has_function('fts_read'))
 
 if wayland_client.version().version_compare('<1.20.0')
   add_project_arguments(
@@ -191,7 +191,7 @@ subdir('test')
 executable(
   'tofi',
   files('src/main.c'), common_sources, wl_proto_src, wl_proto_headers,
-  dependencies: [librt, libm, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix, libfts],
+  dependencies: [librt, libm, libfts, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix],
   install: true
 )
 


### PR DESCRIPTION
Musl libc doesn't provide FTS functions.
For this reasons musl-based systems tend to offer it as a standalone library.

This PR adds detection of whether the libc supports FTS and when it doesn't - requires libfts to be present.