### PR TITLE
Don't generate useless .eh_frame and .eh_frame_hdr

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,8 @@ add_project_arguments(
     '-Wno-unused-parameter',
     '-D_GNU_SOURCE',
     '-D_FORTIFY_SOURCE=2',
+    # Disable these unwind tables for binary size, as we don't use exceptions
+    # or anything else that requires them.
     '-fno-asynchronous-unwind-tables',
   ],
   language: 'c'

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,7 @@ add_project_arguments(
     '-Wno-unused-parameter',
     '-D_GNU_SOURCE',
     '-D_FORTIFY_SOURCE=2',
+    '-fno-asynchronous-unwind-tables',
   ],
   language: 'c'
 )


### PR DESCRIPTION
This project seemingly doesn't use exceptions, attribute(cleanup) or similar techniques, so such sections just add up to binary size.