### PR TITLE
Fix C-[ acting as escape

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -82,7 +82,7 @@ void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 	} else if (sym == XKB_KEY_Page_Down) {
 		select_next_page(tofi);
 	} else if (sym == XKB_KEY_Escape
-			|| ((key == KEY_C || key == KEY_LEFTBRACE) && ctrl)) {
+			|| ((key == KEY_C || sym == XKB_KEY_bracketleft) && ctrl)) {
 		tofi->closed = true;
 		return;
 	} else if (sym == XKB_KEY_Return || sym == XKB_KEY_KP_Enter) {


### PR DESCRIPTION
I assume the changed line was supposed to let C-[ work as escape to close the window.
That didn't work on my system, so I changed it to use the XKB keysym.