### PR TITLE
Return error if no selection is made

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1921,5 +1921,8 @@ int main(int argc, char *argv[])
 	wl_display_disconnect(tofi.wl_display);
 
 	log_debug("Finished, exiting.\n");
+	if (tofi.closed) {
+		return EXIT_FAILURE;
+	}
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Simplify the process of detecting if the output from tofi can be ignored. Return code can now be checked.