### PR TITLE
Add Ctrl+h and Ctrl+m keybindings

### DIFF
--- a/doc/tofi.1.md
+++ b/doc/tofi.1.md
@@ -58,6 +58,10 @@ the form **--key=value**.
 
 > Move the selection forward one page.
 
+\<Backspace\> \| \<Ctrl\>-h
+
+> Delete character.
+
 \<Ctrl\>-u
 
 > Delete line.
@@ -66,7 +70,7 @@ the form **--key=value**.
 
 > Delete word.
 
-\<Enter\>
+\<Enter\> \| \<Ctrl\>-m
 
 > Confirm the current selection and quit.
 

--- a/doc/tofi.1.scd
+++ b/doc/tofi.1.scd
@@ -51,13 +51,16 @@ All config file options described in *tofi*(5) are also accepted, in the form
 <Page Down>
 	Move the selection forward one page.
 
+<Backspace> | <Ctrl>-h
+	Delete character.
+
 <Ctrl>-u
 	Delete line.
 
 <Ctrl>-w | <Ctrl>-<Backspace>
 	Delete word.
 
-<Enter>
+<Enter> | <Ctrl>-m
 	Confirm the current selection and quit.
 
 <Escape> | <Ctrl>-c | <Ctrl>-[

--- a/src/input.c
+++ b/src/input.c
@@ -62,7 +62,8 @@ void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 		add_character(tofi, keycode);
 	} else if ((key == KEY_BACKSPACE || key == KEY_W) && ctrl) {
 		delete_word(tofi);
-	} else if (key == KEY_BACKSPACE) {
+	} else if (key == KEY_BACKSPACE
+			|| (key == KEY_H && ctrl)) {
 		delete_character(tofi);
 	} else if (key == KEY_U && ctrl) {
 		clear_input(tofi);
@@ -94,7 +95,9 @@ void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 			|| ((key == KEY_C || key == KEY_LEFTBRACE) && ctrl)) {
 		tofi->closed = true;
 		return;
-	} else if (key == KEY_ENTER || key == KEY_KPENTER) {
+	} else if (key == KEY_ENTER
+			|| key == KEY_KPENTER
+			|| (key == KEY_M && ctrl)) {
 		tofi->submit = true;
 		return;
 	}
@@ -157,6 +160,8 @@ static uint32_t keysym_to_key(xkb_keysym_t sym)
 			return KEY_ENTER;
 		case XKB_KEY_KP_Enter:
 			return KEY_KPENTER;
+		case XKB_KEY_m:
+			return KEY_M;
 	}
 	return (uint32_t)-1;
 }


### PR DESCRIPTION
As an ex-dmenu/rofi user, I really miss these two terminal/shell-style keybindings:

* Ctrl+h → Delete the preceding character (`0x08`, `BACKSPACE`)
* Ctrl+m → Confirm (`0x0D`, `CARRIAGE RETURN`)

There is another commonly used keybinding for _Confirm_ — Ctrl+j (`0x0A`, `LINE FEED`) — but it is already mapped to _Move Forward_ (anyway, I personally never use Ctrl-j).

