### PR TITLE
Add alternative select return symbol

### DIFF
--- a/doc/tofi.1.md
+++ b/doc/tofi.1.md
@@ -115,6 +115,10 @@ the form **--key=value**.
 
 > An error occurred, or the user exited without making a selection.
 
+2
+
+> Alternative Success; a selection was made, but the user held down control when confirming it. Useful for building "multi-level" select prompts. 
+
 ## AUTHORS
 
 Philip Jones \<<philj56@gmail.com>\>

--- a/src/input.c
+++ b/src/input.c
@@ -94,11 +94,14 @@ void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 			|| ((key == KEY_C || key == KEY_LEFTBRACE) && ctrl)) {
 		tofi->closed = true;
 		return;
+	} else if (ctrl && (key == KEY_ENTER || key == KEY_KPENTER)) {
+		tofi->submit = true;
+		tofi->submit_extra = true;
+		return;
 	} else if (key == KEY_ENTER || key == KEY_KPENTER) {
 		tofi->submit = true;
 		return;
-	}
-
+	} 
 	if (tofi->auto_accept_single && tofi->window.entry.results.count == 1) {
 		tofi->submit = true;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -1924,5 +1924,9 @@ int main(int argc, char *argv[])
 	if (tofi.closed) {
 		return EXIT_FAILURE;
 	}
-	return EXIT_SUCCESS;
+        if(tofi.submit_extra) {
+                return 2;
+        } else {
+                return EXIT_SUCCESS;
+        }
 }

--- a/src/tofi.h
+++ b/src/tofi.h
@@ -54,6 +54,7 @@ struct tofi {
 
 	/* State */
 	bool submit;
+	bool submit_extra;
 	bool closed;
 	int32_t output_width;
 	int32_t output_height;


### PR DESCRIPTION
When holding down **ctrl** during a selection, everything is the same as the standard selection except the status code that gets returned. Currently, I've put 2 there but I guess it's up to debate what status code to return. 

A usecase I have for this is for an extended passmenu (see pass utlity) script that by default returns the password but with the ctrl held down you can select extra fields for the multiline passwords. 

It basically works just fine but if you have some comments or amends you'd want me to make I'd be more than happy to polish this feature.