### PR TITLE
Don't force --require-match in drun mode

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -260,7 +260,6 @@
 
 	# If true, require a match to allow a selection to be made. If false,
 	# making a selection with no matches will print input to stdout.
-	# In drun mode, this is always true.
 	require-match = true
 
 	# If true, automatically accept a result if it is the only one

--- a/doc/tofi.5.md
+++ b/doc/tofi.5.md
@@ -89,8 +89,7 @@ options.
 **require-match**=*true\|false*
 
 > If true, require a match to allow a selection to be made. If false,
-> making a selection with no matches will print input to stdout. In drun
-> mode, this is always true.
+> making a selection with no matches will print input to stdout.
 >
 > Default: true
 

--- a/doc/tofi.5.scd
+++ b/doc/tofi.5.scd
@@ -85,7 +85,6 @@ options.
 *require-match*=_true|false_
 	If true, require a match to allow a selection to be made. If false,
 	making a selection with no matches will print input to stdout.
-	In drun mode, this is always true.
 
 	Default: true
 

--- a/src/main.c
+++ b/src/main.c
@@ -1007,8 +1007,7 @@ static bool do_submit(struct tofi *tofi)
 	char *res = entry->results.buf[selection].string;
 
 	if (tofi->window.entry.results.count == 0) {
-		/* Always require a match in drun mode. */
-		if (tofi->require_match || entry->mode == TOFI_MODE_DRUN) {
+		if (tofi->require_match) {
 			return false;
 		} else {
 			printf("%s\n", entry->input_utf8);


### PR DESCRIPTION
This way you can run commands or other executables on drun mode too, even if they don't show in the list