### PR TITLE
Emacs like keybindings

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -76,13 +76,13 @@ void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 			|| key == KEY_LEFT
 			|| (key == KEY_TAB && shift)
 			|| (key == KEY_H && alt)
-			|| ((key == KEY_K || key == KEY_P) && (ctrl || alt))) {
+			|| ((key == KEY_K || key == KEY_P || key == KEY_B) && (ctrl || alt))) {
 		select_previous_result(tofi);
 	} else if (key == KEY_DOWN
 			|| key == KEY_RIGHT
 			|| key == KEY_TAB
 			|| (key == KEY_L && alt)
-			|| ((key == KEY_J || key == KEY_N) && (ctrl || alt))) {
+			|| ((key == KEY_J || key == KEY_N || key == KEY_F) && (ctrl || alt))) {
 		select_next_result(tofi);
 	} else if (key == KEY_HOME) {
 		reset_selection(tofi);

--- a/src/input.c
+++ b/src/input.c
@@ -91,7 +91,7 @@ void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 	} else if (key == KEY_PAGEDOWN) {
 		select_next_page(tofi);
 	} else if (key == KEY_ESC
-			|| ((key == KEY_C || key == KEY_LEFTBRACE) && ctrl)) {
+			|| ((key == KEY_C || key == KEY_LEFTBRACE || key == KEY_G) && ctrl)) {
 		tofi->closed = true;
 		return;
 	} else if (key == KEY_ENTER || key == KEY_KPENTER) {


### PR DESCRIPTION
Thanks for developing Tofi!

As I use Emacs I added some of my own keybindings to reduce friction and thought they might be useful to others.
Tofi already has C-p and C-n for forwards and backwards, however when displayed horizontally C-f and C-b make more sense.
Additionally, I added C-g to exit Tofi.
