### PR TITLE
fix test linking with external fts

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -8,7 +8,7 @@ foreach test_file : tests
     test_file,
     files(test_file + '.c', 'tap.c'), common_sources, wl_proto_src, wl_proto_headers,
     include_directories: ['../src'],
-    dependencies: [librt, libm, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix],
+    dependencies: [librt, libm, libfts, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix],
     install: false
     )
 


### PR DESCRIPTION
fixes
clang -o test/config ....
ld.lld: error: undefined symbol: fts_close
>>> referenced by drun.c:132 (../src/drun.c:132)

only happens when lto is disabled since the linker won't prune the unused symbols from drun.c early