### PR TITLE
Allowing field expansion in the terminal configuration

### DIFF
--- a/src/drun.c
+++ b/src/drun.c
@@ -356,7 +356,7 @@ void drun_print(const char *filename, const char *terminal_command)
 			log_warning("This probably isn't what you want.\n");
 			log_warning("See the --terminal option documentation in the man page.\n");
 		} else {
-			fputs(terminal_command, stdout);
+			fprintf(stdout, terminal_command, pieces.buf[0].string, pieces.buf[0].string);
 			fputc(' ', stdout);
 		}
 	}


### PR DESCRIPTION
Allowing field expansion in the terminal configuration:

```
terminal=foot --app-id=%s --title=%s
```

closes #169 