### PR TITLE
Mouse support using wheel and buttons

### DIFF
--- a/completions/tofi
+++ b/completions/tofi
@@ -74,6 +74,7 @@ _tofi()
 		--clip-to-padding
 		--horizontal
 		--hide-cursor
+		--mouse-enable
 		--history
 		--history-file
 		--matching-algorithm

--- a/completions/tofi
+++ b/completions/tofi
@@ -74,7 +74,7 @@ _tofi()
 		--clip-to-padding
 		--horizontal
 		--hide-cursor
-		--mouse-enable
+		--mouse
 		--history
 		--history-file
 		--matching-algorithm

--- a/doc/config
+++ b/doc/config
@@ -239,7 +239,7 @@
 	hide-cursor = false
 
 	# Enable the use of the mouse for selection
-	mouse-enable = false
+	mouse = false
 
 	# Show a text cursor in the input field.
 	text-cursor = false

--- a/doc/config
+++ b/doc/config
@@ -238,6 +238,9 @@
 	# Hide the mouse cursor.
 	hide-cursor = false
 
+	# Enable the use of the mouse for selection
+	mouse-enable = false
+
 	# Show a text cursor in the input field.
 	text-cursor = false
 

--- a/doc/tofi.5.md
+++ b/doc/tofi.5.md
@@ -36,7 +36,7 @@ options.
 >
 > Default: false
 
-**mouse-enable**=*true\|false*
+**mouse**=*true\|false*
 
 > Enable the mouse for selection.
 >

--- a/doc/tofi.5.md
+++ b/doc/tofi.5.md
@@ -36,6 +36,12 @@ options.
 >
 > Default: false
 
+**mouse-enable**=*true\|false*
+
+> Enable the mouse for selection.
+>
+> Default: false
+
 **text-cursor**=*true\|false*
 
 > Show a text cursor in the input field.

--- a/doc/tofi.5.scd
+++ b/doc/tofi.5.scd
@@ -38,7 +38,7 @@ options.
 
 	Default: false
 
-*mouse-enable*=_true|false_
+*mouse*=_true|false_
 	Enable the mouse for selection.
 
 	Default: false

--- a/doc/tofi.5.scd
+++ b/doc/tofi.5.scd
@@ -38,6 +38,11 @@ options.
 
 	Default: false
 
+*mouse-enable*=_true|false_
+	Enable the mouse for selection.
+
+	Default: false
+
 *text-cursor*=_true|false_
 	Show a text cursor in the input field.
 

--- a/src/config.c
+++ b/src/config.c
@@ -678,7 +678,7 @@ bool parse_option(struct tofi *tofi, const char *filename, size_t lineno, const 
 		if (!err) {
 			tofi->hide_cursor = val;
 		}
-	} else if (strcasecmp(option, "mouse-enable") == 0) {
+	} else if (strcasecmp(option, "mouse") == 0) {
 		bool val = parse_bool(filename, lineno, value, &err);
 		if (!err) {
 			tofi->mouse_enable = val;

--- a/src/config.c
+++ b/src/config.c
@@ -678,6 +678,11 @@ bool parse_option(struct tofi *tofi, const char *filename, size_t lineno, const 
 		if (!err) {
 			tofi->hide_cursor = val;
 		}
+	} else if (strcasecmp(option, "mouse-enable") == 0) {
+		bool val = parse_bool(filename, lineno, value, &err);
+		if (!err) {
+			tofi->mouse_enable = val;
+		}
 	} else if (strcasecmp(option, "history") == 0) {
 		bool val = parse_bool(filename, lineno, value, &err);
 		if (!err) {

--- a/src/input.c
+++ b/src/input.c
@@ -23,6 +23,20 @@ static void next_cursor_or_result(struct tofi *tofi);
 static void previous_cursor_or_result(struct tofi *tofi);
 static void reset_selection(struct tofi *tofi);
 
+void input_handle_mouse(struct tofi *tofi, mouse_event_t event)
+{
+	if (event == MOUSE_EVENT_WHEEL_UP) select_previous_result(tofi);
+	else if (event == MOUSE_EVENT_WHEEL_DOWN) select_next_result(tofi);
+	else if (event == MOUSE_EVENT_RIGHT_CLICK) {
+		tofi->closed = true;
+		return;
+	} else if (event == MOUSE_EVENT_LEFT_CLICK) {
+		tofi->submit = true;
+		return;
+	}
+	tofi->window.surface.redraw = true;
+}
+
 void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 {
 	if (tofi->xkb_state == NULL) {

--- a/src/input.h
+++ b/src/input.h
@@ -4,6 +4,15 @@
 #include <xkbcommon/xkbcommon.h>
 #include "tofi.h"
 
+typedef enum {
+    MOUSE_EVENT_LEFT_CLICK,
+    MOUSE_EVENT_RIGHT_CLICK,
+    MOUSE_EVENT_MIDDLE_CLICK,
+    MOUSE_EVENT_WHEEL_UP,
+    MOUSE_EVENT_WHEEL_DOWN
+} mouse_event_t;
+
+void input_handle_mouse(struct tofi *tofi, mouse_event_t event);
 void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode);
 void input_refresh_results(struct tofi *tofi);
 

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <wayland-client.h>
 #include <wayland-util.h>
+#include <linux/input-event-codes.h>
 #include <xkbcommon/xkbcommon.h>
 #include "tofi.h"
 #include "compgen.h"
@@ -313,7 +314,19 @@ static void wl_pointer_button(
 		uint32_t button,
 		enum wl_pointer_button_state state)
 {
-	/* Deliberately left blank */
+
+	struct tofi *tofi = data;
+	if (tofi->mouse_enable) {
+		if (state == WL_POINTER_BUTTON_STATE_PRESSED) {
+			if (button == BTN_LEFT) {
+				input_handle_mouse(tofi, MOUSE_EVENT_LEFT_CLICK);
+			} else if (button == BTN_RIGHT) {
+				input_handle_mouse(tofi, MOUSE_EVENT_RIGHT_CLICK);
+			} else if (button == BTN_MIDDLE) {
+				input_handle_mouse(tofi, MOUSE_EVENT_MIDDLE_CLICK);
+			}
+		}
+	}
 }
 
 static void wl_pointer_axis(
@@ -354,7 +367,15 @@ static void wl_pointer_axis_discrete(
 		enum wl_pointer_axis axis,
 		int32_t discrete)
 {
-	/* Deliberately left blank */
+	struct tofi *tofi = data;
+	if (tofi->mouse_enable) {
+		if (axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
+			if (discrete > 0)
+				input_handle_mouse(tofi, MOUSE_EVENT_WHEEL_DOWN);
+			else
+				input_handle_mouse(tofi, MOUSE_EVENT_WHEEL_UP);
+		}
+	}
 }
 
 static const struct wl_pointer_listener wl_pointer_listener = {
@@ -908,6 +929,7 @@ const struct option long_options[] = {
 	{"clip-to-padding", required_argument, NULL, 0},
 	{"horizontal", required_argument, NULL, 0},
 	{"hide-cursor", required_argument, NULL, 0},
+	{"mouse-enable", required_argument, NULL, 0},
 	{"history", required_argument, NULL, 0},
 	{"history-file", required_argument, NULL, 0},
 	{"fuzzy-match", required_argument, NULL, 0},

--- a/src/main.c
+++ b/src/main.c
@@ -929,7 +929,7 @@ const struct option long_options[] = {
 	{"clip-to-padding", required_argument, NULL, 0},
 	{"horizontal", required_argument, NULL, 0},
 	{"hide-cursor", required_argument, NULL, 0},
-	{"mouse-enable", required_argument, NULL, 0},
+	{"mouse", required_argument, NULL, 0},
 	{"history", required_argument, NULL, 0},
 	{"history-file", required_argument, NULL, 0},
 	{"fuzzy-match", required_argument, NULL, 0},

--- a/src/tofi.h
+++ b/src/tofi.h
@@ -94,6 +94,7 @@ struct tofi {
 	enum matching_algorithm matching_algorithm;
 	bool ascii_input;
 	bool hide_cursor;
+	bool mouse_enable;
 	bool use_history;
 	bool use_scale;
 	bool late_keyboard_init;


### PR DESCRIPTION
I have added mouse support (#43) to select an entry using the wheel, confirm with left click and cancel with right click.
This feature is disabled by default unless the setting mouse-enable is set to true.
