### PR TITLE
Added calculator functionnality

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential llvm clang meson scdoc \
+          sudo apt-get install build-essential llvm clang meson scdoc qalc \
           ninja-build libfreetype-dev libharfbuzz-dev libcairo-dev \
           libpango1.0-dev libwayland-dev wayland-protocols libxkbcommon-dev \
           python3-pip
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential llvm clang meson scdoc \
+          sudo apt-get install build-essential llvm clang meson scdoc qalc \
           ninja-build libfreetype-dev libharfbuzz-dev libcairo-dev \
           libpango1.0-dev libwayland-dev wayland-protocols libxkbcommon-dev \
           python3-pip

--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,9 @@ tags
 
 # Project specific files
 build/
+src/build/
+src/meson-info/
+src/meson-logs/
+src/compile_commands.json
+src/build.ninja
 .cache

--- a/doc/config
+++ b/doc/config
@@ -313,6 +313,25 @@
 	ascii-input = false
 
 #
+### Modules
+#
+	# Enable the Math module. A result will be appended to the suggestions
+	# prefixed with "=". Executing this result will copy the math result and
+	# send a notification.
+	module-math = true
+
+	# Enable the Search module. A result will be appended to the suggestions
+	# prefixed with "?". Executing this result will open a browser window
+	# and do a search with the given prompt.
+	module-search = true
+
+	# changes the prefix of the url which will be opend to customize searchengines.
+	module-search-engine = "google.com/search"
+
+	# changes the command which will be used to open the url.
+	module-search-browser = "firefox"
+
+#
 ### Inclusion
 #
 	# Configs can be split between multiple files, and then included

--- a/doc/tofi.5.md
+++ b/doc/tofi.5.md
@@ -630,6 +630,10 @@ options.
 >
 > Default: true
 
+## MODULES
+**module-math**=true|false
+> Calculate Math equations inside the Input field. The Calculation result will appear inside the result-suggestions, when Selecting this result it will be copied to clipboard and a notification will be sent
+
 ## COLORS
 
 Colors can be specified in the form *RGB*, *RGBA*, *RRGGBB* or

--- a/doc/tofi.5.md
+++ b/doc/tofi.5.md
@@ -631,8 +631,31 @@ options.
 > Default: true
 
 ## MODULES
-**module-math**=true|false
-> Calculate Math equations inside the Input field. The Calculation result will appear inside the result-suggestions, when Selecting this result it will be copied to clipboard and a notification will be sent
+
+Modules provide additional functionallity to tofi. All a module does is append
+another suggestion to the displayed list. Each module has a unique Prefix, you
+can execute an module by - as normal - pressing enter while the suggestion is
+selected. **Please be aware that modules execute commands using your input as arguments. This could be dangerous since commands can be escaped by `&&` and alikes. Act carefull and know the risks.**
+
+**module-math**=*true\|false*
+> Calculate Math equations inside the Input field. The Result will be shown inside the suggestions. When executing this module the result will be copied to clipboard and a notification is send. This module has the preifx: `=`.
+>
+> Default: true
+
+**module-search**=*true\|false*
+> Will forward what you've written in the Input Field to an browser in form of a search query. This module has the prefix `?`.
+>
+> Default: false
+
+**module-search-engine**=*string* 
+> You can customize the searchengine by chaning the base URL (without https:// !). The module will append the query (`?q=TEXT`) to the url ending, thus every searchenging using this format is supported! 
+>
+> Default: "google.com/search"
+
+**module-search-browser**=*string*
+> The browser used to search can naturally also be changed, this is the command with which will open the browser (not the browser displayname!).
+>
+> Default: "firefox"
 
 ## COLORS
 

--- a/meson.build
+++ b/meson.build
@@ -116,6 +116,7 @@ common_sources = files(
   'src/surface.c',
   'src/unicode.c',
   'src/xmalloc.c',
+  'src/modules.c',
 )
 
 compgen_sources = files(

--- a/meson.build
+++ b/meson.build
@@ -144,6 +144,7 @@ wayland_scanner_dep = dependency('wayland-scanner', native: true)
 xkbcommon = dependency('xkbcommon')
 glib = dependency('glib-2.0')
 gio_unix = dependency('gio-unix-2.0')
+libqalculate = dependency('libqalculate')
 
 if wayland_client.version().version_compare('<1.20.0')
   add_project_arguments(
@@ -204,7 +205,7 @@ subdir('test')
 executable(
   'tofi',
   files('src/main.c'), common_sources, wl_proto_src, wl_proto_headers,
-  dependencies: [librt, libm, libfts, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix],
+  dependencies: [librt, libm, libfts, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix, libqalculate],
   install: true
 )
 

--- a/src/config.c
+++ b/src/config.c
@@ -769,13 +769,17 @@ bool parse_option(struct tofi *tofi, const char *filename, size_t lineno, const 
     } else if (strcasecmp(option, "module-math") == 0) {
         bool val = parse_bool(filename, lineno, value, &err);
         if (!err) {
-        tofi->module_math = val;
+        tofi->modules.math.enabled = val;
         }
     } else if (strcasecmp(option, "module-search") == 0) {
         bool val = parse_bool(filename, lineno, value, &err);
         if (!err) {
-            tofi->module_search = val;
+            tofi->modules.search.enabled = val;
         }
+	} else if (strcasecmp(option, "module-search-browser") == 0) {
+        snprintf(tofi->modules.search.browser, N_ELEM(tofi->modules.search.browser), "%s", value);
+	} else if (strcasecmp(option, "module-search-engine") == 0) {
+        snprintf(tofi->modules.search.engine, N_ELEM(tofi->modules.search.engine), "%s", value);
 	} else {
 		PARSE_ERROR(filename, lineno, "Unknown option \"%s\"\n", option);
 		err = true;

--- a/src/config.c
+++ b/src/config.c
@@ -766,6 +766,16 @@ bool parse_option(struct tofi *tofi, const char *filename, size_t lineno, const 
 		if (!err) {
 			tofi->use_scale = val;
 		}
+    } else if (strcasecmp(option, "module-math") == 0) {
+        bool val = parse_bool(filename, lineno, value, &err);
+        if (!err) {
+        tofi->module_math = val;
+        }
+    } else if (strcasecmp(option, "module-search") == 0) {
+        bool val = parse_bool(filename, lineno, value, &err);
+        if (!err) {
+            tofi->module_search = val;
+        }
 	} else {
 		PARSE_ERROR(filename, lineno, "Unknown option \"%s\"\n", option);
 		err = true;

--- a/src/desktop_vec.c
+++ b/src/desktop_vec.c
@@ -6,6 +6,7 @@
 #include "string_vec.h"
 #include "unicode.h"
 #include "xmalloc.h"
+#include "modules.h"
 
 static bool match_current_desktop(char * const *desktop_list, gsize length);
 
@@ -148,6 +149,7 @@ struct desktop_entry *desktop_vec_find_sorted(struct desktop_vec *restrict vec, 
 }
 
 struct string_ref_vec desktop_vec_filter(
+        struct tofi *tofi,
 		const struct desktop_vec *restrict vec,
 		const char *restrict substr,
 		enum matching_algorithm algorithm)
@@ -175,6 +177,10 @@ struct string_ref_vec desktop_vec_filter(
 			}
 		}
 	}
+
+    // add suggestions form enabled modules
+    modules_suggest(tofi, substr, &filt);
+
 	/*
 	 * Sort the results by this search_score. This moves matches at the beginnings
 	 * of words to the front of the result list.

--- a/src/desktop_vec.h
+++ b/src/desktop_vec.h
@@ -35,8 +35,10 @@ void desktop_vec_add_file(struct desktop_vec *desktop, const char *id, const cha
 
 void desktop_vec_sort(struct desktop_vec *restrict vec);
 struct desktop_entry *desktop_vec_find_sorted(struct desktop_vec *restrict vec, const char *name);
+struct tofi;
 struct string_ref_vec desktop_vec_filter(
-		const struct desktop_vec *restrict vec,
+		struct tofi *tofi,
+        const struct desktop_vec *restrict vec,
 		const char *restrict substr,
 		enum matching_algorithm algorithm);
 

--- a/src/input.c
+++ b/src/input.c
@@ -26,10 +26,6 @@ static void reset_selection(struct tofi *tofi);
 
 void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 {
-	if (tofi->xkb_state == NULL) {
-		return;
-	}
-
 	bool ctrl = xkb_state_mod_name_is_active(
 			tofi->xkb_state,
 			XKB_MOD_NAME_CTRL,
@@ -42,6 +38,14 @@ void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 			tofi->xkb_state,
 			XKB_MOD_NAME_SHIFT,
 			XKB_STATE_MODS_EFFECTIVE);
+
+	if (tofi->xkb_state == NULL) {
+		return;
+	}
+	// Ignore "-char to prevent escaping the commands used for math and search
+	if (11 == keycode && shift) {
+		return;
+	}
 
 	uint32_t ch = xkb_state_key_get_utf32(tofi->xkb_state, keycode);
 

--- a/src/input.c
+++ b/src/input.c
@@ -203,7 +203,7 @@ void add_character(struct tofi *tofi, xkb_keycode_t keycode)
 		entry->input_utf8_length += len;
 
 		if (entry->mode == TOFI_MODE_DRUN) {
-			struct string_ref_vec results = desktop_vec_filter(&entry->apps, entry->input_utf8, tofi->matching_algorithm);
+			struct string_ref_vec results = desktop_vec_filter(tofi, &entry->apps, entry->input_utf8, tofi->matching_algorithm);
 			string_ref_vec_destroy(&entry->results);
 			entry->results = results;
 		} else {
@@ -241,7 +241,7 @@ void input_refresh_results(struct tofi *tofi)
 	entry->input_utf8_length = bytes_written;
 	string_ref_vec_destroy(&entry->results);
 	if (entry->mode == TOFI_MODE_DRUN) {
-		entry->results = desktop_vec_filter(&entry->apps, entry->input_utf8, tofi->matching_algorithm);
+		entry->results = desktop_vec_filter(tofi, &entry->apps, entry->input_utf8, tofi->matching_algorithm);
 	} else {
 		entry->results = string_ref_vec_filter(&entry->commands, entry->input_utf8, tofi->matching_algorithm);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -1031,7 +1031,7 @@ static bool do_submit(struct tofi *tofi)
 			}
 		}
 		if (app == NULL) {
-            if (modules_try_execute(res, entry->input_utf8))
+            if (modules_try_execute(tofi, res, entry->input_utf8))
                 return true;
 			log_error("Couldn't find application file! This shouldn't happen.\n");
 			return false;
@@ -1203,8 +1203,16 @@ int main(int argc, char *argv[])
 		.require_match = true,
 		.use_scale = true,
 		.physical_keybindings = true,
-        .module_math = true,
-        .module_search = false
+        .modules = {
+            .math = {
+                .enabled = true
+            },
+            .search = {
+                .enabled = false,
+                .browser = "firefox",
+                .engine = "google.com/search"
+            }
+        }
 	};
 	wl_list_init(&tofi.output_list);
 	if (getenv("TERMINAL") != NULL) {

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include <wayland-client.h>
 #include <wayland-util.h>
 #include <xkbcommon/xkbcommon.h>
+#include "src/modules.h"
 #include "tofi.h"
 #include "compgen.h"
 #include "drun.h"
@@ -1030,6 +1031,8 @@ static bool do_submit(struct tofi *tofi)
 			}
 		}
 		if (app == NULL) {
+            if (modules_try_execute(res, entry->input_utf8))
+                return true;
 			log_error("Couldn't find application file! This shouldn't happen.\n");
 			return false;
 		}
@@ -1200,6 +1203,8 @@ int main(int argc, char *argv[])
 		.require_match = true,
 		.use_scale = true,
 		.physical_keybindings = true,
+        .module_math = true,
+        .module_search = false
 	};
 	wl_list_init(&tofi.output_list);
 	if (getenv("TERMINAL") != NULL) {

--- a/src/modules.c
+++ b/src/modules.c
@@ -67,6 +67,7 @@ bool module_search_selected(char *restrict query) {
 
 void modules_suggest(struct tofi *tofi, char *restrict query,
                      struct string_ref_vec *filt) {
+  if (strlen(query) == 0) return;
   if (tofi->module_math)
     module_math_suggestion(query, filt);
   if (tofi->module_search)

--- a/src/modules.c
+++ b/src/modules.c
@@ -62,7 +62,7 @@ bool module_search_selected(struct tofi *tofi, char *restrict query) {
   strncat(command, tofi->modules.search.engine, sizeof(command)-1);
   strncat(command, "?q=", sizeof(command) - 1);
   strncat(command, query, sizeof(command) - 1);
-  strncat(command, "\"", sizeof(command) - 1);
+  strncat(command, "\" &", sizeof(command) - 1);
 
   system(command);
   // return is here to avoid an ugly switch

--- a/src/modules.c
+++ b/src/modules.c
@@ -1,0 +1,86 @@
+#include "modules.h"
+#include "history.h"
+#include "string_vec.h"
+#include "unicode.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void module_math_suggestion(const char *restrict query,
+                            struct string_ref_vec *filt) {
+  char command[128] = "qalc -t -m 1000  \"";
+  command[sizeof(command) - 1] = '\0'; // Ensure null termination
+  strncat(command, query, sizeof(command) - 1);
+  strncat(command, "\"", sizeof(command) - 1);
+
+  char result[128] = "";
+
+  // execute command
+  FILE *fp = popen(command, "r");
+  // limit output to 50 characters
+  fgets(result, 50, fp);
+  pclose(fp);
+
+  // add module prefix
+  char finalresult[128] = "=";
+  strncat(finalresult, result, sizeof(finalresult) - 1);
+  finalresult[strlen(finalresult) - 1] = '\0'; // Ensure null termination
+
+  string_ref_vec_add(filt, utf8_normalize(finalresult));
+}
+
+bool module_math_selected(char *suggestion, char *query) {
+  char notify[128] = "notify-send \"Calculation: ";
+  // set notification title to be the calculation
+  strncat(notify, query, sizeof(notify) - 1);
+  strncat(notify, "\" \"", sizeof(notify) - 1);
+  // set notification body to be result
+  strncat(notify, suggestion, sizeof(notify) - 1);
+  strncat(notify, "\"", sizeof(notify) - 1);
+
+  char copy[128] = "wl-copy \"";
+  strncat(copy, suggestion, sizeof(notify) - 1);
+  strncat(copy, "\"", sizeof(notify) - 1);
+
+  system(copy);
+  system(notify);
+
+  // return is here to avoid an ugly switch
+  return true;
+}
+
+void module_search_suggestion(char *restrict query,
+                              struct string_ref_vec *restrict filt) {
+  // always display this to avoid duplicate string
+  string_ref_vec_add(filt, "?search");
+}
+
+bool module_search_selected(char *restrict query) {
+  char command[128] = "firefox --search \"";
+  strncat(command, query, sizeof(command) - 1);
+  strncat(command, "\"", sizeof(command) - 1);
+
+  system(command);
+  // return is here to avoid an ugly switch
+  return true;
+}
+
+void modules_suggest(struct tofi *tofi, char *restrict query,
+                     struct string_ref_vec *filt) {
+  if (tofi->module_math)
+    module_math_suggestion(query, filt);
+  if (tofi->module_search)
+    module_search_suggestion(query, filt);
+}
+
+bool modules_try_execute(char *suggestion, char *restrict query) {
+  char prefix = suggestion[0];
+  // remove first character (prefix)
+  suggestion++;
+  switch (prefix) {
+  case '=':
+    return module_math_selected(suggestion, query);
+  case '?':
+    return module_search_selected(query);
+  }
+}

--- a/src/modules.h
+++ b/src/modules.h
@@ -1,0 +1,10 @@
+#ifndef MODULES_H
+#define MODULES_H
+
+#include "tofi.h"
+
+void modules_suggest(struct tofi *tofi, char *restrict query,
+                     struct string_ref_vec *filt);
+bool modules_try_execute(char *suggestion, char *restrict query);
+
+#endif /* MKDIRP_H */

--- a/src/modules.h
+++ b/src/modules.h
@@ -5,6 +5,6 @@
 
 void modules_suggest(struct tofi *tofi, char *restrict query,
                      struct string_ref_vec *filt);
-bool modules_try_execute(char *suggestion, char *restrict query);
+bool modules_try_execute(struct tofi *tofi, char *suggestion, char *restrict query);
 
 #endif /* MKDIRP_H */

--- a/src/tofi.h
+++ b/src/tofi.h
@@ -104,6 +104,8 @@ struct tofi {
 	bool print_index;
 	bool multiple_instance;
 	bool physical_keybindings;
+    bool module_math;
+    bool module_search;
 	char target_output_name[MAX_OUTPUT_NAME_LEN];
 	char default_terminal[MAX_TERMINAL_NAME_LEN];
 	char history_file[MAX_HISTORY_FILE_NAME_LEN];

--- a/src/tofi.h
+++ b/src/tofi.h
@@ -104,8 +104,16 @@ struct tofi {
 	bool print_index;
 	bool multiple_instance;
 	bool physical_keybindings;
-    bool module_math;
-    bool module_search;
+    struct {
+        struct {
+            bool enabled
+        } math;
+        struct {
+            bool enabled;
+            char browser[128];
+            char engine[128];
+        } search;
+    } modules;
 	char target_output_name[MAX_OUTPUT_NAME_LEN];
 	char default_terminal[MAX_TERMINAL_NAME_LEN];
 	char history_file[MAX_HISTORY_FILE_NAME_LEN];

--- a/test/meson.build
+++ b/test/meson.build
@@ -8,7 +8,7 @@ foreach test_file : tests
     test_file,
     files(test_file + '.c', 'tap.c'), common_sources, wl_proto_src, wl_proto_headers,
     include_directories: ['../src'],
-    dependencies: [librt, libm, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix],
+    dependencies: [librt, libm, freetype, harfbuzz, cairo, pangocairo, wayland_client, xkbcommon, glib, gio_unix, libqalculate],
     install: false
     )
 


### PR DESCRIPTION
We've extended the codebase to allow for modules like doing math or doing a web search to be added fairly easily.

This pull request includes those two examples. Modules are asked to add their suggestion to the results array, importantly module suggestions must start with a prefix (e.g. `=` for calcuations `?` for searches). Then when the user selects the result of an module, the module can process text-input and its own suggestion to do a task. All modules can be disabled in the config file.

The Math modules uses `qalc` or `libqalculate` from the AUR as the "calculation backend" which is now a required dependency (at least we think so)

The PR also includes functionality for the delete key to remove the next character :D

Still todo is:
- [x] Documentation about this feature
- [ ] Also add this modules functionality to non drun
- [ ] Maybe add a way to have a better module prefix system (TBD)
- [ ] Tofi seams to not end its process when executing the math module
**(A temporary fix for that is adding ` && wl-copy "" ` behind your key bind)**
- [x] Entering `"` breaks the calculation module
- [x] Tofi seams to crash when trying to remove the last existing character
- [x] Add extended configuration for the search module (change search engine or browser) and find a way to utilize the default browser

Sadly `^` cant be used for e.g. doing math, presumably it's a "dead key" and there doesn't seam to be any easy workaround. You can still use `**` to do exponents though: e.g. `3**4 = 3⁴`

Should close https://github.com/philj56/tofi/issues/172 and https://github.com/philj56/tofi/issues/183