### PR TITLE
doc: add explicit mention of tofi's usage as launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ executables under the user's `$PATH`.
 list of applications found in desktop files as described by the [Desktop Entry
 Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html).
 
-To use as a launcher for Sway, add something similar to the following to your
+To use as a launcher, tofi's output needs to be fed into another program (e.g. window-manager's exec function).  
+For example in Sway add something similar to the following to your
 Sway config file:
 ```
 set $menu tofi-run | xargs swaymsg exec --


### PR DESCRIPTION
Hi,
I believe this would make some peoples setup experience easier.
(If one doesn't realize that the `xargs ...` part is actually needed, searching for the reason why nothing launches is difficult and the only answer I found was in a response to one issue)