### PR TITLE
Implement `double` parsing for `font-size`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tofi
+# Tofi (fork)
 
 An extremely fast and simple [dmenu](https://tools.suckless.org/dmenu/) /
 [rofi](https://github.com/davatorium/rofi) replacement for
@@ -14,6 +14,7 @@ single frame.
 ![](screenshot_fullscreen.png)
 
 ## Table of Contents
+* [What's new](#whats-new)
 * [Install](#install)
   * [Building](#building)
   * [Arch](#arch)
@@ -24,6 +25,11 @@ single frame.
   * [Benchmarks](#benchmarks)
   * [Where is the time spent?](#where-is-the-time-spent)
 
+## What's new
+* Implemented `DELETE` key logic (thanks to @F-4Dev)
+* Added fractional font-size support (for example Departure Mono is 8.5pt (11px) on 96DPI)
+* Added raw shell commands in run mode. Tofi will now return full command string with arguments passed by the user.
+* Added `TAB` completions (thanks to @achuie and @rdao)
 ## Install
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ single frame.
   * [Where is the time spent?](#where-is-the-time-spent)
 
 ## What's new
-* Implemented `DELETE` key logic (thanks to @F-4Dev)
+* Implemented `DELETE` key logic (thanks to [@F-4Dev](https://github.com/F-4Dev))
 * Added fractional font-size support (for example Departure Mono is 8.5pt (11px) on 96DPI)
 * Added raw shell commands in run mode. Tofi will now return full command string with arguments passed by the user.
-* Added `TAB` completions (thanks to @achuie and @rdao)
+* Added `TAB` completions (thanks to [@achuie](https://github.com/achuie) and [@rdap](https://github.com/rdap))
 ## Install
 ### Building
 

--- a/doc/tofi.5.scd
+++ b/doc/tofi.5.scd
@@ -61,26 +61,16 @@ options.
 		- tofi-run:  _$XDG_STATE_HOME/tofi-history_
 		- tofi-drun: _$XDG_STATE_HOME/tofi-drun-history_
 
-*matching-algorithm*=_normal|prefix|fuzzy_
+*matching-algorithm*=_normal|prefix|fuzzy|command_
 	Select the matching algorithm used.
 	If _normal_, substring matching is used, weighted to favour matches
 	closer to the beginning of the string.
 	If _prefix_, only substrings at the beginning of the string are matched.
 	If _fuzzy_, searching is performed via a simple fuzzy matching
 	algorithm.
+	If _command_, only first word called _command__ is matched.
 
 	Default: normal
-
-*fuzzy-match*=_true|false_
-	*WARNING*: This option is deprecated, and may be removed in a future
-	version of tofi. You should use the *matching-algorithm*
-	option instead.
-
-	If true, searching is performed via a simple fuzzy matching algorithm.
-	If false, substring matching is used, weighted to favour matches closer
-	to the beginning of the string.
-
-	Default: false
 
 *require-match*=_true|false_
 	If true, require a match to allow a selection to be made. If false,

--- a/src/config.c
+++ b/src/config.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
+#include "matching.h"
 #include "tofi.h"
 #include "color.h"
 #include "config.h"
@@ -689,15 +690,7 @@ bool parse_option(struct tofi *tofi, const char *filename, size_t lineno, const 
 	} else if (strcasecmp(option, "matching-algorithm") == 0) {
 		enum matching_algorithm val = parse_matching_algorithm(filename, lineno, value, &err);
 		if (!err) {
-			tofi->matching_algorithm= val;
-		}
-	} else if (strcasecmp(option, "fuzzy-match") == 0) {
-		log_warning("The \"fuzzy-match\" option is deprecated, and may be removed in future. Please switch to \"matching-algorithm\".\n");
-		bool val = parse_bool(filename, lineno, value, &err);
-		if (!err) {
-			if (val) {
-				tofi->matching_algorithm = MATCHING_ALGORITHM_FUZZY;
-			}
+			tofi->matching_algorithm = val;
 		}
 	} else if (strcasecmp(option, "require-match") == 0) {
 		bool val = parse_bool(filename, lineno, value, &err);
@@ -1008,12 +1001,12 @@ enum matching_algorithm parse_matching_algorithm(const char *filename, size_t li
 {
 	if(strcasecmp(str, "normal") == 0) {
 		return MATCHING_ALGORITHM_NORMAL;
-	}
-	if(strcasecmp(str, "fuzzy") == 0) {
+	} else if(strcasecmp(str, "fuzzy") == 0) {
 		return MATCHING_ALGORITHM_FUZZY;
-	}
-	if(strcasecmp(str, "prefix") == 0) {
+	} else if(strcasecmp(str, "prefix") == 0) {
 		return MATCHING_ALGORITHM_PREFIX;
+	} else if (strcasecmp(str, "command") == 0) {
+		return MATCHING_ALGORITHM_COMMAND;
 	}
 	PARSE_ERROR(filename, lineno, "Invalid matching algorithm \"%s\".\n", str);
 	if (err) {

--- a/src/entry.h
+++ b/src/entry.h
@@ -105,7 +105,7 @@ struct entry {
 	uint32_t num_results_drawn;
 	uint32_t last_num_results_drawn;
 	int32_t result_spacing;
-	uint32_t font_size;
+	double font_size;
 	char font_name[MAX_FONT_NAME_LENGTH];
 	char font_features[MAX_FONT_FEATURES_LENGTH];
 	char font_variations[MAX_FONT_VARIATIONS_LENGTH];

--- a/src/entry_backend/harfbuzz.c
+++ b/src/entry_backend/harfbuzz.c
@@ -465,7 +465,7 @@ void entry_backend_harfbuzz_init(
 {
 	struct entry_backend_harfbuzz *hb = &entry->harfbuzz;
 	cairo_t *cr = entry->cairo[0].cr;
-	uint32_t font_size = floor(entry->font_size * PT_TO_DPI);
+	double font_size = floor(entry->font_size * PT_TO_DPI);
 	cairo_surface_get_device_scale(entry->cairo[0].surface, &hb->scale, NULL);
 
 	/*

--- a/src/input.c
+++ b/src/input.c
@@ -4,6 +4,7 @@
 #include <unistd.h>
 #include "input.h"
 #include "log.h"
+#include "matching.h"
 #include "nelem.h"
 #include "tofi.h"
 #include "unicode.h"
@@ -201,6 +202,10 @@ void add_character(struct tofi *tofi, xkb_keycode_t keycode)
 			struct string_ref_vec results = desktop_vec_filter(&entry->apps, entry->input_utf8, tofi->matching_algorithm);
 			string_ref_vec_destroy(&entry->results);
 			entry->results = results;
+		} else if (entry->mode == TOFI_MODE_RUN) {
+			struct string_ref_vec tmp = entry->results;
+			entry->results = string_ref_vec_filter(&entry->results, entry->input_utf8, MATCHING_ALGORITHM_COMMAND);
+			string_ref_vec_destroy(&tmp);
 		} else {
 			struct string_ref_vec tmp = entry->results;
 			entry->results = string_ref_vec_filter(&entry->results, entry->input_utf8, tofi->matching_algorithm);

--- a/src/input.c
+++ b/src/input.c
@@ -12,7 +12,8 @@
 
 static uint32_t keysym_to_key(xkb_keysym_t sym);
 static void add_character(struct tofi *tofi, xkb_keycode_t keycode);
-static void delete_character(struct tofi *tofi);
+static void delete_prev_character(struct tofi *tofi);
+static void delete_next_character(struct tofi *tofi);
 static void delete_word(struct tofi *tofi);
 static void clear_input(struct tofi *tofi);
 static void paste(struct tofi *tofi);
@@ -65,7 +66,10 @@ void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 		delete_word(tofi);
 	} else if (key == KEY_BACKSPACE
 			|| (key == KEY_H && ctrl)) {
-		delete_character(tofi);
+		delete_prev_character(tofi);
+	} else if (key == KEY_DELETE
+			|| (key == KEY_L && ctrl)) {
+		delete_next_character(tofi);
 	} else if (key == KEY_U && ctrl) {
 		clear_input(tofi);
 	} else if (key == KEY_V && ctrl) {
@@ -115,6 +119,8 @@ static uint32_t keysym_to_key(xkb_keysym_t sym)
 	switch (sym) {
 		case XKB_KEY_BackSpace:
 			return KEY_BACKSPACE;
+		case XKB_KEY_Delete:
+			return KEY_DELETE;
 		case XKB_KEY_w:
 			return KEY_W;
 		case XKB_KEY_u:
@@ -249,7 +255,7 @@ void input_refresh_results(struct tofi *tofi)
 	reset_selection(tofi);
 }
 
-void delete_character(struct tofi *tofi)
+void delete_prev_character(struct tofi *tofi)
 {
 	struct entry *entry = &tofi->window.entry;
 
@@ -269,6 +275,28 @@ void delete_character(struct tofi *tofi)
 			entry->input_utf32[i] = entry->input_utf32[i + 1];
 		}
 		entry->cursor_position--;
+		entry->input_utf32_length--;
+		entry->input_utf32[entry->input_utf32_length] = U'\0';
+	}
+
+	input_refresh_results(tofi);
+}
+
+void delete_next_character(struct tofi *tofi) 
+{
+	struct entry *entry = &tofi->window.entry;
+
+	if (entry->input_utf32_length == 0) {
+		/* No input to delete. */
+		return;
+	}
+
+	if (entry->cursor_position == entry->input_utf32_length) {
+		return;
+	} else {
+		for (size_t i = entry->cursor_position + 1; i < entry->input_utf32_length - 1; i++) {
+			entry->input_utf32[i] = entry->input_utf32[i + 1];
+		}
 		entry->input_utf32_length--;
 		entry->input_utf32[entry->input_utf32_length] = U'\0';
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -13,6 +13,7 @@
 #include <wayland-client.h>
 #include <wayland-util.h>
 #include <xkbcommon/xkbcommon.h>
+#include "src/matching.h"
 #include "tofi.h"
 #include "compgen.h"
 #include "drun.h"
@@ -1048,7 +1049,20 @@ static bool do_submit(struct tofi *tofi)
 				}
 			}
 		} else {
-			printf("%s\n", res);
+			if (entry->input_utf8_length > strlen(res)) {
+				char *input = entry->input_utf8;
+				size_t res_len = strlen(res);
+				char *args = NULL;
+				if (strlen(input) > res_len) {
+					args = input + res_len;
+					while (*args == ' ') args++;
+				} else {
+					args = "";
+				}
+				printf("%s %s\n", res, args);
+			} else {
+				printf("%s\n", res);
+			}
 		}
 	}
 	if (tofi->use_history) {

--- a/src/matching.c
+++ b/src/matching.c
@@ -19,6 +19,10 @@ static int32_t prefix_match_words(
 		const char *restrict patterns,
 		const char *restrict str);
 
+static int32_t command_match_words(
+		const char *restrict patterns,
+		const char *restrict str);
+
 static int32_t fuzzy_match_words(
 		const char *restrict patterns,
 		const char *restrict str);
@@ -56,6 +60,8 @@ int32_t match_words(
 			return prefix_match_words(patterns, str);
 		case MATCHING_ALGORITHM_FUZZY:
 			return fuzzy_match_words(patterns, str);
+		case MATCHING_ALGORITHM_COMMAND:
+			return command_match_words(patterns, str);
 		default:
 			return INT32_MIN;
 	}
@@ -111,6 +117,27 @@ int32_t prefix_match_words(const char *restrict patterns, const char *restrict s
 	return score;
 }
 
+/*
+ * Split patterns into words, treat the first as the command and perform
+ * matching, against it. If a word is not found, returns INT32_MIN.
+ */
+int32_t command_match_words(const char *patterns, const char *str) {
+    if (!patterns || !*patterns)
+        return INT32_MIN;
+
+    size_t len = 0;
+    while (patterns[len] && patterns[len] != ' ')
+        len++;
+
+    if (len == 0)
+        return INT32_MIN;
+
+    char first_word[len + 1];
+    memcpy(first_word, patterns, len);
+    first_word[len] = '\0';
+
+    return simple_match_words(first_word, str);
+}
 
 /*
  * Split patterns into words, and return the sum of fuzzy_match(word, str).

--- a/src/matching.h
+++ b/src/matching.h
@@ -6,7 +6,8 @@
 enum matching_algorithm {
 	MATCHING_ALGORITHM_NORMAL,
 	MATCHING_ALGORITHM_PREFIX,
-	MATCHING_ALGORITHM_FUZZY
+	MATCHING_ALGORITHM_FUZZY,
+	MATCHING_ALGORITHM_COMMAND
 };
 
 int32_t match_words(enum matching_algorithm algorithm, const char *restrict patterns, const char *restrict str);

--- a/test/utf8.c
+++ b/test/utf8.c
@@ -23,6 +23,7 @@ void is_match(const char *pattern, const char *str, const char *message)
 	is_single_match(MATCHING_ALGORITHM_NORMAL, pattern, str, message);
 	is_single_match(MATCHING_ALGORITHM_PREFIX, pattern, str, message);
 	is_single_match(MATCHING_ALGORITHM_FUZZY, pattern, str, message);
+	is_single_match(MATCHING_ALGORITHM_COMMAND, pattern, str, message);
 }
 
 void isnt_match(const char *pattern, const char *str, const char *message)
@@ -30,6 +31,7 @@ void isnt_match(const char *pattern, const char *str, const char *message)
 	isnt_single_match(MATCHING_ALGORITHM_NORMAL, pattern, str, message);
 	isnt_single_match(MATCHING_ALGORITHM_PREFIX, pattern, str, message);
 	isnt_single_match(MATCHING_ALGORITHM_FUZZY, pattern, str, message);
+	isnt_single_match(MATCHING_ALGORITHM_COMMAND, pattern, str, message);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
Current implementation only accepts integers for font size, which is incorrect. Many bitmap fonts use fixed font sizes (for example, Departure Mono, which uses 11px or 8.5pt at 96 DPI). This PR only adds simple function to parse `double`s and and implements it around the code.