### PR TITLE
feat: add stdout event support (proof-of-concept)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ single frame.
   * [Arch](#arch)
 * [Usage](#usage)
   * [Theming](#theming)
+* [Event Streaming](#event-streaming)
 * [Performance](#performance)
   * [Options](#options)
   * [Benchmarks](#benchmarks)
@@ -144,6 +145,135 @@ tweak them to look correct on your display.
 
 [`themes/soy-milk`](themes/soy-milk)
 ![Soy milk theme screenshot](screenshot_soy_milk.png)
+
+## Event Streaming
+
+Tofi can output a stream of JSON events to stderr, enabling external tools to
+react to user interactions in real-time. This is useful for building wrappers,
+previews, or custom integrations around tofi.
+
+### Enabling Event Streaming
+
+Enable via command line:
+```sh
+tofi --stream-events
+```
+
+Or in your config file:
+```
+stream-events = true
+```
+
+### Event Types
+
+All events are emitted as single-line JSON objects to stderr.
+
+#### `open`
+
+Emitted once when tofi opens and is ready to accept input.
+
+```json
+{
+  "event": "open",
+  "mode": "plain",
+  "items": 42,
+  "window": {"x": 100, "y": 200, "width": 800, "height": 600},
+  "output": {"width": 1920, "height": 1080}
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `mode` | One of `"plain"`, `"run"`, or `"drun"` |
+| `items` | Total number of items available |
+| `window.x`, `window.y` | Calculated window position on screen |
+| `window.width`, `window.height` | Window dimensions |
+| `output.width`, `output.height` | Output (monitor) dimensions |
+
+#### `input`
+
+Emitted when the user types or modifies the input field.
+
+```json
+{"event": "input", "value": "fire", "results": 3}
+```
+
+| Field | Description |
+|-------|-------------|
+| `value` | Current input text |
+| `results` | Number of matching results |
+
+#### `select`
+
+Emitted when the selection changes (arrow keys, page up/down, etc.). Also
+emitted once on open if there are results.
+
+```json
+{"event": "select", "index": 2, "value": "firefox"}
+```
+
+| Field | Description |
+|-------|-------------|
+| `index` | Zero-based index in the filtered result list |
+| `value` | Text of the selected item |
+
+#### `submit`
+
+Emitted when the user confirms their selection (Enter key).
+
+```json
+{"event": "submit", "index": 0, "value": "firefox"}
+```
+
+| Field | Description |
+|-------|-------------|
+| `index` | Zero-based index of the submitted item |
+| `value` | Text of the submitted item |
+
+#### `close`
+
+Emitted when tofi closes without a selection.
+
+```json
+{"event": "close", "reason": "escape"}
+```
+
+| Field | Description |
+|-------|-------------|
+| `reason` | Why tofi closed (currently `"escape"` for user cancellation) |
+
+### Example: Live Preview Script
+
+This example uses `jq` to parse events and display a preview of the selected
+item:
+
+```bash
+#!/bin/bash
+# preview-launcher.sh
+
+tofi-drun --stream-events 2>&1 >/dev/null | while read -r event; do
+    type=$(echo "$event" | jq -r '.event')
+    case "$type" in
+        select)
+            value=$(echo "$event" | jq -r '.value')
+            echo "Preview: $value"
+            # Could trigger a preview window, fetch an icon, etc.
+            ;;
+        submit)
+            value=$(echo "$event" | jq -r '.value')
+            echo "Launching: $value"
+            ;;
+    esac
+done
+```
+
+### Notes
+
+- Events are written to stderr, so stdout remains available for the final
+  selection result.
+- JSON strings are properly escaped (newlines, quotes, backslashes, tabs).
+- The `select` event fires for every navigation action, including page
+  changes.
 
 ## Performance
 

--- a/meson.build
+++ b/meson.build
@@ -104,6 +104,7 @@ common_sources = files(
   'src/entry.c',
   'src/entry_backend/pango.c',
   'src/entry_backend/harfbuzz.c',
+  'src/events.c',
   'src/matching.c',
   'src/history.c',
   'src/input.c',

--- a/src/config.c
+++ b/src/config.c
@@ -729,6 +729,11 @@ bool parse_option(struct tofi *tofi, const char *filename, size_t lineno, const 
 		if (!err) {
 			tofi->physical_keybindings = val;
 		}
+	} else if (strcasecmp(option, "stream-events") == 0) {
+		bool val = parse_bool(filename, lineno, value, &err);
+		if (!err) {
+			tofi->stream_events = val;
+		}
 	} else if (strcasecmp(option, "drun-launch") == 0) {
 		bool val = parse_bool(filename, lineno, value, &err);
 		if (!err) {

--- a/src/events.c
+++ b/src/events.c
@@ -1,0 +1,149 @@
+#include <stdio.h>
+#include <stddef.h>
+#include "events.h"
+#include "tofi.h"
+#include "wlr-layer-shell-unstable-v1.h"
+
+static void escape_json_string(const char *in, char *out, size_t out_size)
+{
+	size_t j = 0;
+	for (size_t i = 0; in[i] && j < out_size - 2; i++) {
+		switch (in[i]) {
+			case '"':
+				out[j++] = '\\';
+				out[j++] = '"';
+				break;
+			case '\\':
+				out[j++] = '\\';
+				out[j++] = '\\';
+				break;
+			case '\n':
+				out[j++] = '\\';
+				out[j++] = 'n';
+				break;
+			case '\r':
+				out[j++] = '\\';
+				out[j++] = 'r';
+				break;
+			case '\t':
+				out[j++] = '\\';
+				out[j++] = 't';
+				break;
+			default:
+				out[j++] = in[i];
+				break;
+		}
+	}
+	out[j] = '\0';
+}
+
+void event_open(struct tofi *tofi)
+{
+	if (!tofi->stream_events) {
+		return;
+	}
+
+	const char *mode;
+	switch (tofi->window.entry.mode) {
+		case TOFI_MODE_RUN:
+			mode = "run";
+			break;
+		case TOFI_MODE_DRUN:
+			mode = "drun";
+			break;
+		default:
+			mode = "plain";
+			break;
+	}
+
+	/* Calculate window position based on anchor and margins */
+	uint32_t anchor = tofi->anchor;
+	int32_t win_x, win_y;
+	int32_t out_w = tofi->output_width;
+	int32_t out_h = tofi->output_height;
+	int32_t win_w = tofi->window.width;
+	int32_t win_h = tofi->window.height;
+
+	/* Horizontal position */
+	if ((anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT) &&
+	    (anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT)) {
+		/* Centered horizontally */
+		win_x = (out_w - win_w) / 2;
+	} else if (anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT) {
+		win_x = tofi->window.margin_left;
+	} else if (anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT) {
+		win_x = out_w - win_w - tofi->window.margin_right;
+	} else {
+		win_x = (out_w - win_w) / 2;
+	}
+
+	/* Vertical position */
+	if ((anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP) &&
+	    (anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM)) {
+		/* Centered vertically */
+		win_y = (out_h - win_h) / 2;
+	} else if (anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP) {
+		win_y = tofi->window.margin_top;
+	} else if (anchor & ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM) {
+		win_y = out_h - win_h - tofi->window.margin_bottom;
+	} else {
+		win_y = (out_h - win_h) / 2;
+	}
+
+	fprintf(stderr, "{\"event\":\"open\",\"mode\":\"%s\",\"items\":%zu,"
+			"\"window\":{\"x\":%d,\"y\":%d,\"width\":%u,\"height\":%u},"
+			"\"output\":{\"width\":%d,\"height\":%d}}\n",
+			mode, tofi->window.entry.results.count,
+			win_x, win_y, win_w, win_h,
+			out_w, out_h);
+	fflush(stderr);
+}
+
+void event_input(struct tofi *tofi, const char *input, size_t result_count)
+{
+	if (!tofi->stream_events) {
+		return;
+	}
+
+	char escaped[4096];
+	escape_json_string(input, escaped, sizeof(escaped));
+	fprintf(stderr, "{\"event\":\"input\",\"value\":\"%s\",\"results\":%zu}\n",
+			escaped, result_count);
+	fflush(stderr);
+}
+
+void event_select(struct tofi *tofi, uint32_t index, const char *value)
+{
+	if (!tofi->stream_events) {
+		return;
+	}
+
+	char escaped[4096];
+	escape_json_string(value, escaped, sizeof(escaped));
+	fprintf(stderr, "{\"event\":\"select\",\"index\":%u,\"value\":\"%s\"}\n",
+			index, escaped);
+	fflush(stderr);
+}
+
+void event_submit(struct tofi *tofi, uint32_t index, const char *value)
+{
+	if (!tofi->stream_events) {
+		return;
+	}
+
+	char escaped[4096];
+	escape_json_string(value, escaped, sizeof(escaped));
+	fprintf(stderr, "{\"event\":\"submit\",\"index\":%u,\"value\":\"%s\"}\n",
+			index, escaped);
+	fflush(stderr);
+}
+
+void event_close(struct tofi *tofi, const char *reason)
+{
+	if (!tofi->stream_events) {
+		return;
+	}
+
+	fprintf(stderr, "{\"event\":\"close\",\"reason\":\"%s\"}\n", reason);
+	fflush(stderr);
+}

--- a/src/events.h
+++ b/src/events.h
@@ -1,0 +1,14 @@
+#ifndef EVENTS_H
+#define EVENTS_H
+
+#include <stdint.h>
+
+struct tofi;
+
+void event_open(struct tofi *tofi);
+void event_input(struct tofi *tofi, const char *input, size_t result_count);
+void event_select(struct tofi *tofi, uint32_t index, const char *value);
+void event_submit(struct tofi *tofi, uint32_t index, const char *value);
+void event_close(struct tofi *tofi, const char *reason);
+
+#endif /* EVENTS_H */

--- a/src/input.c
+++ b/src/input.c
@@ -2,6 +2,7 @@
 #include <fcntl.h>
 #include <linux/input-event-codes.h>
 #include <unistd.h>
+#include "events.h"
 #include "input.h"
 #include "log.h"
 #include "nelem.h"
@@ -93,6 +94,7 @@ void input_handle_keypress(struct tofi *tofi, xkb_keycode_t keycode)
 		select_next_page(tofi);
 	} else if (key == KEY_ESC
 			|| ((key == KEY_C || key == KEY_LEFTBRACE || key == KEY_G) && ctrl)) {
+		event_close(tofi, "escape");
 		tofi->closed = true;
 		return;
 	} else if (key == KEY_ENTER
@@ -242,6 +244,7 @@ void input_refresh_results(struct tofi *tofi)
 	}
 
 	reset_selection(tofi);
+	event_input(tofi, entry->input_utf8, entry->results.count);
 }
 
 void delete_character(struct tofi *tofi)
@@ -332,12 +335,22 @@ void paste(struct tofi *tofi)
 	tofi->clipboard.fd = fildes[0];
 }
 
+static void emit_selection_event(struct tofi *tofi)
+{
+	struct entry *entry = &tofi->window.entry;
+	uint32_t idx = entry->selection + entry->first_result;
+	if (idx < entry->results.count) {
+		event_select(tofi, idx, entry->results.buf[idx].string);
+	}
+}
+
 void select_previous_result(struct tofi *tofi)
 {
 	struct entry *entry = &tofi->window.entry;
 
 	if (entry->selection > 0) {
 		entry->selection--;
+		emit_selection_event(tofi);
 		return;
 	}
 
@@ -350,6 +363,7 @@ void select_previous_result(struct tofi *tofi)
 		entry->selection = entry->first_result - 1;
 		entry->first_result = 0;
 	}
+	emit_selection_event(tofi);
 }
 
 void select_next_result(struct tofi *tofi)
@@ -369,6 +383,7 @@ void select_next_result(struct tofi *tofi)
 		}
 		entry->last_num_results_drawn = entry->num_results_drawn;
 	}
+	emit_selection_event(tofi);
 }
 
 void previous_cursor_or_result(struct tofi *tofi)
@@ -407,6 +422,7 @@ void select_previous_page(struct tofi *tofi)
 	}
 	entry->selection = 0;
 	entry->last_num_results_drawn = entry->num_results_drawn;
+	emit_selection_event(tofi);
 }
 
 void select_next_page(struct tofi *tofi)
@@ -419,4 +435,5 @@ void select_next_page(struct tofi *tofi)
 	}
 	entry->selection = 0;
 	entry->last_num_results_drawn = entry->num_results_drawn;
+	emit_selection_event(tofi);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@
 #include "drun.h"
 #include "config.h"
 #include "entry.h"
+#include "events.h"
 #include "input.h"
 #include "log.h"
 #include "nelem.h"
@@ -918,6 +919,7 @@ const struct option long_options[] = {
 	{"hide-input", required_argument, NULL, 0},
 	{"hidden-character", required_argument, NULL, 0},
 	{"physical-keybindings", required_argument, NULL, 0},
+	{"stream-events", optional_argument, NULL, 's'},
 	{"drun-launch", required_argument, NULL, 0},
 	{"drun-print-exec", required_argument, NULL, 0},
 	{"terminal", required_argument, NULL, 0},
@@ -989,6 +991,17 @@ static void parse_args(struct tofi *tofi, int argc, char *argv[])
 			} else {
 				tofi->late_keyboard_init = true;
 			}
+		} else if (opt == 's') {
+			/*
+			 * Handle --stream-events with optional argument.
+			 */
+			if (optarg) {
+				if (!config_apply(tofi, long_options[option_index].name, optarg)) {
+					exit(EXIT_FAILURE);
+				}
+			} else {
+				tofi->stream_events = true;
+			}
 		}
 		opt = getopt_long(argc, argv, short_options, long_options, &option_index);
 	}
@@ -1005,6 +1018,8 @@ static bool do_submit(struct tofi *tofi)
 	struct entry *entry = &tofi->window.entry;
 	uint32_t selection = entry->selection + entry->first_result;
 	char *res = entry->results.buf[selection].string;
+
+	event_submit(tofi, selection, res);
 
 	if (tofi->window.entry.results.count == 0) {
 		/* Always require a match in drun mode. */
@@ -1743,6 +1758,14 @@ int main(int argc, char *argv[])
 		free(tofi.xkb_keymap_string);
 		tofi.late_keyboard_init = false;
 		log_debug("Keyboard configured.\n");
+	}
+
+	/* Emit open event for stream consumers. */
+	event_open(&tofi);
+
+	/* Emit initial select event if there are results. */
+	if (tofi.window.entry.results.count > 0) {
+		event_select(&tofi, 0, tofi.window.entry.results.buf[0].string);
 	}
 
 	/*

--- a/src/tofi.h
+++ b/src/tofi.h
@@ -104,6 +104,7 @@ struct tofi {
 	bool print_index;
 	bool multiple_instance;
 	bool physical_keybindings;
+	bool stream_events;
 	char target_output_name[MAX_OUTPUT_NAME_LEN];
 	char default_terminal[MAX_TERMINAL_NAME_LEN];
 	char history_file[MAX_HISTORY_FILE_NAME_LEN];


### PR DESCRIPTION
This is a proof-of-concept for enabling scripting around `tofi` while it's running. For example, creating a clipboard history navigator with a preview window positioned relatively to tofi:

<img width="2308" height="875" alt="image" src="https://github.com/user-attachments/assets/c1f6340b-7fa3-4c26-ba6c-8aa5f56d3850" />

<img width="2302" height="876" alt="image" src="https://github.com/user-attachments/assets/a47148aa-8c1b-4898-8e5a-a5b6a69b114d" />

<img width="2300" height="869" alt="image" src="https://github.com/user-attachments/assets/c76b0930-646c-4234-ae5f-f7eec8e4ae3f" />

I'm happy to keep this in my own fork, but I'll put up a PR for a while as an interest check.  I don't think the implementation is good, and JSON is probably not the correct format considering tofi's minimal approach.